### PR TITLE
PTW-46: allow constructor strategy for uuid through config

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Formatter.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Formatter.php
@@ -43,6 +43,7 @@ class Formatter extends BaseFormatter
     const CFG_QUOTE_IDENTIFIER_STRATEGY             = 'quoteIdentifierStrategy';
     const CFG_USE_BEHAVIORAL_EXTENSIONS             = 'useBehavioralExtensions';
     const CFG_API_PLATFORM_ANNOTATIONS              = 'apiPlatformAnnotations';
+    const CFG_RASMEY_UUID_PROVIDER                  = 'rasmeyUuidProvider';
 
     const QUOTE_IDENTIFIER_AUTO                     = 'auto';
     const QUOTE_IDENTIFIER_ALWAYS                   = 'always';
@@ -64,6 +65,7 @@ class Formatter extends BaseFormatter
             static::CFG_EXTENDS_CLASS                       => '',
             static::CFG_PROPERTY_TYPEHINT                   => false,
             static::CFG_API_PLATFORM_ANNOTATIONS            => false,
+            static::CFG_RASMEY_UUID_PROVIDER                => false
         ));
         $this->addValidators(array(
             static::CFG_QUOTE_IDENTIFIER_STRATEGY           => new ChoiceValidator(array(

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
@@ -113,9 +113,7 @@ class Column extends BaseColumn
 
             if ($this->isPrimary) {
 
-                $isImportedPrimaryKey = $this->getComment(false) === CustomComment::PRIMARY_KEY_REQUIRES_EXTERNAL_IMPORT ?? false;
-
-                if ($isImportedPrimaryKey) {
+                if ($this->isImportedPrimaryKey()) {
                     $writer
                         ->write('/**')
                         ->write(' * Set the value of ' . $this->getColumnName() . '.')
@@ -222,5 +220,20 @@ class Column extends BaseColumn
         }
 
         return $attributes;
+    }
+
+    /**
+     * Checks if column is commented as requiring external id import
+     * @return bool
+     */
+    private function isImportedPrimaryKey(): bool {
+        return (bool)(
+            $this->parseComment(
+                CustomComment::PRIMARY_KEY_REQUIRES_EXTERNAL_IMPORT,
+                $this->getComment()
+            ) === 'true'
+            ??
+            false
+        );
     }
 }

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
@@ -64,9 +64,7 @@ class Column extends BaseColumn
 
             if($this->isUuid()) {
                 $writer
-                    ->write(' * '.$this->getTable()->getAnnotation('Column', ['type' => 'uuid', 'unique' => true]))
-                    ->write(' * '.$this->getTable()->getAnnotation('GeneratedValue', array('strategy' => 'CUSTOM')))
-                    ->write(' * '.$this->getTable()->getAnnotation('CustomIdGenerator', array('class' => 'Ramsey\Uuid\Doctrine\UuidGenerator')))
+                    ->write(' * '.$this->getTable()->getAnnotation('Column', ['type' => 'guid', 'unique' => true]))
                 ;
             } else {
                 $writer
@@ -112,24 +110,27 @@ class Column extends BaseColumn
                 $typehint = $shouldTypehintProperties && class_exists($nativeType) ? "?$nativeType " : '';
             }
 
-            $writer
-                // setter
-                ->write('/**')
-                ->write(' * Set the value of '.$this->getColumnName().'.')
-                ->write(' *')
-                ->write(' * @param '.$nativeType.' $'.$this->getColumnName())
-                ->write(' * @return '.$table->getNamespace())
-                ->write(' */')
-                ->write('public function set'.$this->getBeautifiedColumnName().'('.$typehint.'$'.$this->getColumnName().')')
-                ->write('{')
-                ->indent()
+            if(!$this->isPrimary) {
+                $writer
+                    // setter
+                    ->write('/**')
+                    ->write(' * Set the value of '.$this->getColumnName().'.')
+                    ->write(' *')
+                    ->write(' * @param '.$nativeType.' $'.$this->getColumnName())
+                    ->write(' * @return '.$table->getNamespace())
+                    ->write(' */')
+                    ->write('public function set'.$this->getBeautifiedColumnName().'('.$typehint.'$'.$this->getColumnName().')')
+                    ->write('{')
+                    ->indent()
                     ->write('$this->'.$this->getColumnName().' = $'.$this->getColumnName().';')
                     ->write('')
                     ->write('return $this;')
-                ->outdent()
-                ->write('}')
-                ->write('')
-                // getter
+                    ->outdent()
+                    ->write('}')
+                    ->write('');
+            }
+
+            $writer
                 ->write('/**')
                 ->write(' * Get the value of '.$this->getColumnName().'.')
                 ->write(' *')

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
@@ -111,71 +111,11 @@ class Column extends BaseColumn
                 $typehint = $shouldTypehintProperties && class_exists($nativeType) ? "?$nativeType " : '';
             }
 
-            if ($this->isPrimary) {
-
-                if ($this->isImportedPrimaryKey()) {
-                    $writer
-                        ->write('/**')
-                        ->write(' * Set the value of ' . $this->getColumnName() . '.')
-                        ->write(' *')
-                        ->write(' * @param ' . $nativeType . ' $' . $this->getColumnName())
-                        ->write(' * @return ' . $table->getNamespace())
-                        ->write(' */')
-                        ->write('public function set' . $this->getBeautifiedColumnName() . '(' . $typehint . '$' . $this->getColumnName() . ')')
-                        ->write('{')
-                        ->indent()
-                        ->write('$this->' . $this->getColumnName() . ' = $' . $this->getColumnName() . ';')
-                        ->write('')
-                        ->write('return $this;')
-                        ->outdent()
-                        ->write('}')
-                        ->write('');
-                }
-
-                $writer->write('/**')
-                    ->write(' * Get the value of ' . $this->getColumnName() . '.')
-                    ->write(' *')
-                    ->write(' * @return ' . $nativeType)
-                    ->write(' */')
-                    ->write('public function get' . $this->getBeautifiedColumnName() . '()')
-                    ->write('{')
-                    ->indent()
-                    ->write('return $this->' . $this->getColumnName() . ';')
-                    ->outdent()
-                    ->write('}')
-                    ->write('');
-
-                return $this;
+            if (!$this->isPrimary || $this->isImportedPrimaryKey()) {
+                $this->writeSetter($writer, $nativeType, $table, $typehint);
             }
 
-            $writer
-                ->write('/**')
-                ->write(' * Set the value of '.$this->getColumnName().'.')
-                ->write(' *')
-                ->write(' * @param '.$nativeType.' $'.$this->getColumnName())
-                ->write(' * @return '.$table->getNamespace())
-                ->write(' */')
-                ->write('public function set'.$this->getBeautifiedColumnName().'('.$typehint.'$'.$this->getColumnName().')')
-                ->write('{')
-                ->indent()
-                ->write('$this->'.$this->getColumnName().' = $'.$this->getColumnName().';')
-                ->write('')
-                ->write('return $this;')
-                ->outdent()
-                ->write('}')
-                ->write('')
-                ->write('/**')
-                ->write(' * Get the value of '.$this->getColumnName().'.')
-                ->write(' *')
-                ->write(' * @return '.$nativeType)
-                ->write(' */')
-                ->write('public function get'.$this->getBeautifiedColumnName().'()')
-                ->write('{')
-                ->indent()
-                ->write('return $this->'.$this->getColumnName().';')
-                ->outdent()
-                ->write('}')
-                ->write('');
+            $this->writeGetter($writer, $nativeType);
         }
 
         return $this;
@@ -235,5 +175,51 @@ class Column extends BaseColumn
             ??
             false
         );
+    }
+
+    /**
+     * @param WriterInterface $writer
+     * @param string $nativeType
+     * @param Table $table
+     * @param string $typehint
+     */
+    private function writeSetter(WriterInterface $writer, string $nativeType, Table $table, string $typehint): void {
+        $columnName = $this->getColumnName();
+        $writer
+            ->write('/**')
+            ->write(' * Set the value of ' . $columnName . '.')
+            ->write(' *')
+            ->write(' * @param ' . $nativeType . ' $' . $columnName)
+            ->write(' * @return ' . $table->getNamespace())
+            ->write(' */')
+            ->write('public function set' . $this->getBeautifiedColumnName() . '(' . $typehint . '$' . $columnName . ')')
+            ->write('{')
+            ->indent()
+            ->write('$this->' . $columnName . ' = $' . $columnName . ';')
+            ->write('')
+            ->write('return $this;')
+            ->outdent()
+            ->write('}')
+            ->write('');
+    }
+
+    /**
+     * @param WriterInterface $writer
+     * @param string $nativeType
+     */
+    private function writeGetter(WriterInterface $writer, string $nativeType): void {
+        $columnName = $this->getColumnName();
+        $writer->write('/**')
+            ->write(' * Get the value of ' . $columnName . '.')
+            ->write(' *')
+            ->write(' * @return ' . $nativeType)
+            ->write(' */')
+            ->write('public function get' . $this->getBeautifiedColumnName() . '()')
+            ->write('{')
+            ->indent()
+            ->write('return $this->' . $columnName . ';')
+            ->outdent()
+            ->write('}')
+            ->write('');
     }
 }

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
@@ -27,14 +27,13 @@
 
 namespace MwbExporter\Formatter\Doctrine2\Annotation\Model;
 
-use MwbExporter\Formatter\Doctrine2\Model\Table as BaseTable;
 use MwbExporter\Formatter\Doctrine2\Annotation\Formatter;
+use MwbExporter\Formatter\Doctrine2\Model\Table as BaseTable;
+use MwbExporter\Helper\Comment;
+use MwbExporter\Helper\ReservedWords;
 use MwbExporter\Model\ForeignKey;
 use MwbExporter\Object\Annotation;
 use MwbExporter\Writer\WriterInterface;
-use MwbExporter\Helper\Comment;
-use MwbExporter\Helper\ReservedWords;
-use Doctrine\Common\Inflector\Inflector;
 
 class Table extends BaseTable
 {
@@ -444,6 +443,10 @@ class Table extends BaseTable
             $uses[] = 'ApiPlatform\Core\Annotation\ApiResource';
         }
 
+        if($this->getConfig()->get(Formatter::CFG_RASMEY_UUID_PROVIDER)) {
+            $uses[] = 'Ramsey\Uuid\Uuid';
+        }
+
         return $uses;
     }
 
@@ -715,10 +718,22 @@ class Table extends BaseTable
 
     public function writeConstructor(WriterInterface $writer)
     {
+        $rasmeyUuidProvider  = $this->getConfig()->get(Formatter::CFG_RASMEY_UUID_PROVIDER);
+
+        /** @var Column $column */
+        foreach ($this->columns as $column) {
+            if ($column->isPrimary()) {
+                $id = $column->getName();
+            }
+        }
+
         $writer
-            ->write('public function __construct()')
+            ->writeIf($rasmeyUuidProvider, 'public function __construct(?string $uuid = null)')
+            ->writeIf(!$rasmeyUuidProvider, 'public function __construct()')
             ->write('{')
             ->indent()
+            ->writeIf($rasmeyUuidProvider, '$uuid = $uuid ? $uuid : Uuid::uuid1()->toString();')
+            ->writeIf(($rasmeyUuidProvider && $id), '$this->'.$id.' = $uuid;')
                 ->writeCallback(function(WriterInterface $writer, Table $_this = null) {
                     $_this->writeCurrentTimestampConstructor($writer);
                     $_this->writeRelationsConstructor($writer);

--- a/lib/MwbExporter/Formatter/Doctrine2/CustomComment.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/CustomComment.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2;
+
+/**
+ * A dictionary class of what is known in the exporter and therfore can safely be used in mysql workbench as comment
+ *
+ * Class CustomOnCorpsComment
+ * @package MwbExporter\Formatter\Doctrine2
+ */
+class CustomComment
+{
+    const PRIMARY_KEY_REQUIRES_EXTERNAL_IMPORT = '<d:external>true</d:external>';
+}

--- a/lib/MwbExporter/Formatter/Doctrine2/CustomComment.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/CustomComment.php
@@ -11,5 +11,5 @@ namespace MwbExporter\Formatter\Doctrine2;
  */
 class CustomComment
 {
-    const PRIMARY_KEY_REQUIRES_EXTERNAL_IMPORT = '<d:external>true</d:external>';
+    const PRIMARY_KEY_REQUIRES_EXTERNAL_IMPORT = 'external_id';
 }


### PR DESCRIPTION
PR following reported issue https://oncorps.atlassian.net/browse/PTW-46 
- Adds configurations for uuid provider 
- Allows uuid to be set through constructor 
- Writes constructor content with uuid generation and assignment on primary key
- Don't write setter for primary keys (constructor would do)

