### PR TITLE
Ptw 68

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Column.php
@@ -28,6 +28,7 @@
 namespace MwbExporter\Formatter\Doctrine2\Annotation\Model;
 
 use MwbExporter\Formatter\Doctrine2\Annotation\Formatter;
+use MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion\PropertyLevelAssertionBuilderProvider;
 use MwbExporter\Formatter\Doctrine2\CustomComment;
 use MwbExporter\Formatter\Doctrine2\Model\Column as BaseColumn;
 use MwbExporter\Writer\WriterInterface;
@@ -52,6 +53,9 @@ class Column extends BaseColumn
 
     public function writeVar(WriterInterface $writer)
     {
+        $propertyLevelBuilder = (new PropertyLevelAssertionBuilderProvider())->getPropertyLevelAssertionBuilder();
+        $columnAssertions = $propertyLevelBuilder->buildAnnotations($this);
+
         if (!$this->isIgnored()) {
             $useBehavioralExtensions = $this->getConfig()->get(Formatter::CFG_USE_BEHAVIORAL_EXTENSIONS);
             $isBehavioralColumn = strstr($this->getTable()->getName(), '_img') && $useBehavioralExtensions;
@@ -62,6 +66,12 @@ class Column extends BaseColumn
                 ->writeIf($this->isPrimary,
                         ' * '.$this->getTable()->getAnnotation('Id'))
             ;
+
+            if ($columnAssertions) {
+                foreach ($columnAssertions as $columnAssertion) {
+                    $writer->writeIf($columnAssertion, $columnAssertion);
+                }
+            }
 
             if($this->isUuid()) {
                 $writer
@@ -91,7 +101,7 @@ class Column extends BaseColumn
                 ->write('protected $'.$this->getColumnName().$this->getStringDefaultValue().';')
                 ->write('')
             ;
-        }
+        } 
 
         return $this;
     }

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/AssertionAnnotationInterface.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/AssertionAnnotationInterface.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
+
+interface AssertionAnnotationInterface
+{
+    public function getUsage(): string;
+}

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/ClassLevelAssertionAnnotationBuilder.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/ClassLevelAssertionAnnotationBuilder.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
+
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Column;
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Table;
+
+class ClassLevelAssertionAnnotationBuilder extends ClassLevelAssertionAnnotationStack
+{
+    /**
+     * ClassLevelAssertionAnnotationBuilder constructor.
+     *
+     * @param array $assertionBuilderClasses
+     */
+    public function __construct(array $assertionBuilderClasses)
+    {
+        parent::__construct($assertionBuilderClasses);
+    }
+
+    /**
+     * @param Column $column
+     * @param Table $table
+     *
+     * @return array|null array of strings (annotation to be written), null if none found.
+     */
+    public function buildAnnotations(Table $table): ?array
+    {
+        $classLevelAnnotations = [];
+
+        /** @var ClassLevelAssertionAnnotationInterface $assertionAnnotationClass */
+        foreach ($this->getStack() as $assertionAnnotationClass) {
+            try {
+                $classLevelAnnotations[] = $assertionAnnotationClass->buildAnnotation($table);
+                //don't let one break all the others:
+            } catch (\Exception $exception) {
+                //@todo a logger would be better here:
+                echo $exception->getMessage();
+            }
+        }
+
+        if (count($classLevelAnnotations) == 0) {
+            return null;
+        }
+
+        return $classLevelAnnotations;
+    }
+}

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/ClassLevelAssertionAnnotationInterface.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/ClassLevelAssertionAnnotationInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
+
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Table;
+
+interface ClassLevelAssertionAnnotationInterface extends AssertionAnnotationInterface
+{
+    public function buildAnnotation(Table $table): ?string;
+}

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/ClassLevelAssertionAnnotationStack.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/ClassLevelAssertionAnnotationStack.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
+
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Column;
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Table;
+
+abstract class ClassLevelAssertionAnnotationStack
+{
+
+    /** @var array */
+    private $assertionAnnotationStack;
+
+    /**
+     * Validates the presence of AssertionAnnotationInterface classes in stack
+     *
+     * AssertionAnnotation constructor.
+     *
+     * @param array $assertionAnnotation
+     */
+    public function __construct(array $assertionBuilderClasses)
+    {
+        foreach ($assertionBuilderClasses as $assertionBuilderClass) {
+            if (
+                !($assertionBuilderClass instanceof ClassLevelAssertionAnnotationInterface)
+                &&
+                !($assertionBuilderClass instanceof AssertionAnnotationInterface)
+            ) {
+                throw new \RuntimeException(
+                    'Only ClassLevelAssertionAnnotationInterface are allowed as constructor array for ClassLevelAssertionAnnotationStack'
+                );
+            }
+        }
+
+        $this->assertionAnnotationStack = $assertionBuilderClasses;
+    }
+
+    public function getStack(): array
+    {
+        return $this->assertionAnnotationStack;
+    }
+}

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/ClassLevelAssertionBuilderProvider.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/ClassLevelAssertionBuilderProvider.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
+
+/**
+ * Config class for tuning the stack for the builder and getting it
+ * Class ClassLevelBuilderProvider
+ * @package MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion
+ */
+class ClassLevelAssertionBuilderProvider
+{
+    /**
+     * @return ClassLevelAssertionAnnotationBuilder
+     */
+    public function getClassLevelAssertionBuilder()
+    {
+        $builder = new ClassLevelAssertionAnnotationBuilder(
+            [
+                new UniqueEntityAssertion(),
+                //Add more class level assertion builder single class here, the stack will call the rest
+            ]
+        );
+
+        return $builder;
+    }
+
+    /**
+     * Foreach configured single classLevelAssertionBuilder in getClassLevelAssertionBuilder returns his usage
+     * @return array
+     */
+    public function getUsages(): array {
+        $uses = [];
+        /** @var ClassLevelAssertionAnnotationInterface $classLevelAssertionBuilder */
+        foreach ($this->getClassLevelAssertionBuilder()->getStack() as $classLevelAssertionBuilder) {
+            $uses[] = $classLevelAssertionBuilder->getUsage();
+        }
+
+        return $uses;
+    }
+}

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/NotNullAssertion.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/NotNullAssertion.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
+
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Column;
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Table;
+
+/**
+ * Builds Unique Entity assertion analysing the primaries in the table.
+ *
+ * Class UniqueEntityAssertion
+ * @package MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion
+ */
+class NotNullAssertion implements PropertyLevelAssertionAnnotationInterface
+{
+    public function buildAnnotation(Column $column): ?string
+    {
+        if($column->getNullableValue() == null) {
+            return ' * @NotNull()';
+        }
+
+        return null;
+    }
+
+    public function getUsage(): string
+    {
+        return 'Symfony\Component\Validator\Constraints\NotNull';
+    }
+}

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/PropertyLevelAssertionAnnotationBuilder.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/PropertyLevelAssertionAnnotationBuilder.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
+
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Column;
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Table;
+
+class PropertyLevelAssertionAnnotationBuilder extends PropertyLevelAssertionAnnotationStack
+{
+    /**
+     * ClassLevelAssertionAnnotationBuilder constructor.
+     *
+     * @param array $assertionBuilderClasses
+     */
+    public function __construct(array $assertionBuilderClasses)
+    {
+        parent::__construct($assertionBuilderClasses);
+    }
+
+    /**
+     * @param Column $column
+     *
+     * @return array|null array of strings (annotation to be written), null if none found.
+     */
+    public function buildAnnotations(Column $column): ?array
+    {
+        $classLevelAnnotations = [];
+
+        /** @var PropertyLevelAssertionAnnotationInterface $assertionAnnotationClass */
+        foreach ($this->getStack() as $assertionAnnotationClass) {
+            try {
+                $propertyLevelAnnotations[] = $assertionAnnotationClass->buildAnnotation($column);
+                //don't let one break all the others:
+            } catch (\Exception $exception) {
+                //@todo a logger would be better here:
+                echo $exception->getMessage();
+            }
+        }
+
+        if (count($propertyLevelAnnotations) == 0) {
+            return null;
+        }
+
+        return $propertyLevelAnnotations;
+    }
+}

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/PropertyLevelAssertionAnnotationInterface.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/PropertyLevelAssertionAnnotationInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
+
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Column;
+
+interface PropertyLevelAssertionAnnotationInterface extends AssertionAnnotationInterface
+{
+    public function buildAnnotation(Column $table): ?string;
+}

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/PropertyLevelAssertionAnnotationStack.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/PropertyLevelAssertionAnnotationStack.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
+
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Column;
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Table;
+
+abstract class PropertyLevelAssertionAnnotationStack
+{
+
+    /** @var array */
+    private $assertionAnnotationStack;
+
+    /**
+     * Validates the presence of AssertionAnnotationInterface classes in stack
+     *
+     * AssertionAnnotation constructor.
+     *
+     * @param array $assertionAnnotation
+     */
+    public function __construct(array $assertionBuilderClasses)
+    {
+        foreach ($assertionBuilderClasses as $assertionBuilderClass) {
+            if (
+                !($assertionBuilderClass instanceof PropertyLevelAssertionAnnotationInterface)
+                &&
+                !($assertionBuilderClass instanceof AssertionAnnotationInterface)
+            ) {
+                throw new \RuntimeException(
+                    'Only PropertyLevelAssertionAnnotationInterface are allowed as constructor array for PropertyLevelAssertionAnnotationStack'
+                );
+            }
+        }
+
+        $this->assertionAnnotationStack = $assertionBuilderClasses;
+    }
+
+    public function getStack(): array
+    {
+        return $this->assertionAnnotationStack;
+    }
+}

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/PropertyLevelAssertionBuilderProvider.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/PropertyLevelAssertionBuilderProvider.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
+
+/**
+ * Config class for tuning the stack for the builder and getting it
+ * Class ClassLevelBuilderProvider
+ * @package MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion
+ */
+class PropertyLevelAssertionBuilderProvider
+{
+    /**
+     * @return PropertyLevelAssertionAnnotationBuilder
+     */
+    public function getPropertyLevelAssertionBuilder()
+    {
+        $builder = new PropertyLevelAssertionAnnotationBuilder(
+            [
+                new NotNullAssertion(),
+                //Add more property level assertion builder single class here, the stack will call the rest
+            ]
+        );
+
+        return $builder;
+    }
+
+    /**
+     * Foreach configured single propertyLevelAssertionBuilder in getPropertyLevelAssertionBuilder returns his usage
+     * @return array
+     */
+    public function getUsages(): array {
+        $uses = [];
+        /** @var PropertyLevelAssertionAnnotationStack $propertyLevelAssertionBuilder */
+        foreach ($this->getPropertyLevelAssertionBuilder()->getStack() as $propertyLevelAssertionBuilder) {
+            $uses[] = $propertyLevelAssertionBuilder->getUsage();
+        }
+
+        return $uses;
+    }
+}

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/UniqueEntityAssertion.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/UniqueEntityAssertion.php
@@ -13,7 +13,7 @@ use MwbExporter\Formatter\Doctrine2\Annotation\Model\Table;
  */
 class UniqueEntityAssertion implements ClassLevelAssertionAnnotationInterface
 {
-    public function buildAnnotation(Table $table): string
+    public function buildAnnotation(Table $table): ?string
     {
         $primaries = [];
         foreach ($table->getColumns() as $column) {

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/UniqueEntityAssertion.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/UniqueEntityAssertion.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
+
+use MwbExporter\Formatter\Doctrine2\Annotation\Model\Table;
+
+/**
+ * Builds Unique Entity assertion analysing the primaries in the table.
+ *
+ * Class UniqueEntityAssertion
+ * @package MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion
+ */
+class UniqueEntityAssertion implements ClassLevelAssertionAnnotationInterface
+{
+    public function buildAnnotation(Table $table): string
+    {
+        $primaries = [];
+        foreach ($table->getColumns() as $column) {
+            if ($column->isPrimary()) {
+                $primaries[] = '"' . $column->getColumnName() . '"';
+            }
+        }
+
+        if (count($primaries) == 0) {
+            return null;
+        }
+
+        $primaries = implode(",", $primaries);
+
+        return ' * @UniqueEntity(fields={' . $primaries . '},message="' . str_replace('"', '', $primaries) . ' needs to be unique")';
+    }
+
+    public function getUsage(): string
+    {
+        return 'Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity';
+    }
+}


### PR DESCRIPTION
@peterchallett this is bringing in a way to collect assertion annotations for classes and property.
All we need to do to extend with further constraint will be:
create a new specific assertion annotation provider class and add that to `ClassLevelAssertionBuilderProvider` or `PropertyLevelAssertionBuilderProvider` respectively for class level or property level annotation.
Apart from the pattern to build those this PR also provides 2 working basic annotation:
- `UniqueEntityAssertion` for classes (listing all primary keys as fields, should already work with composite keys)
- `NotNullAssertion` for property that are not nullable in the schema


ps: I'm currently not sure, so not attempting that for the moment, how to write property level assertion for "not ignored" join columns (any light/suggestion on that would be good)