### PR TITLE
Ptw 68 - 2

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/NotNullAssertion.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/NotNullAssertion.php
@@ -5,6 +5,7 @@ namespace MwbExporter\Formatter\Doctrine2\Annotation\OnCorps\Assertion;
 
 use MwbExporter\Formatter\Doctrine2\Annotation\Model\Column;
 use MwbExporter\Formatter\Doctrine2\Annotation\Model\Table;
+use MwbExporter\Object\Annotation;
 
 /**
  * Builds Unique Entity assertion analysing the primaries in the table.
@@ -20,6 +21,16 @@ class NotNullAssertion implements PropertyLevelAssertionAnnotationInterface
             return ' * @NotNull()';
         }
 
+        return null;
+    }
+
+    public function buildAnnotationForJoinColumn(array $joinAnnotation): ?string
+    {
+        if(isset($joinAnnotation['nullable'])) {
+            if($joinAnnotation['nullable'] == false) {
+                return ' * @NotNull()';
+            }
+        }
         return null;
     }
 

--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/PropertyLevelAssertionAnnotationInterface.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/OnCorps/Assertion/PropertyLevelAssertionAnnotationInterface.php
@@ -8,4 +8,6 @@ use MwbExporter\Formatter\Doctrine2\Annotation\Model\Column;
 interface PropertyLevelAssertionAnnotationInterface extends AssertionAnnotationInterface
 {
     public function buildAnnotation(Column $table): ?string;
+
+    public function buildAnnotationForJoinColumn(array $annotationContent): ?string;
 }


### PR DESCRIPTION
Introduces a `buildAnnotationForJoinColumn` method for `PropertyLevelAssertios` so that from a Table class, given an already constructed `ORM JoinColumn` annotation we could utilise that information to then build an Assertion annotation based on the content of that.

The `PropertyLevelAssertionAnnotationBuilder` needs btw to do reflection to access the content of the annotation as higher package didn't implemented a getContent() method. 

Should be safe as this new call it's wrapped in a try{}catch{}

Expectation of this on a sample ERD would be having the following NotNull automatically annotated as it reads "nullable=false" in the ORM annotation:
<img width="732" alt="Screenshot 2019-07-30 at 17 04 55" src="https://user-images.githubusercontent.com/7916161/62145298-7ae2ed00-b2f3-11e9-9641-3828e049160e.png">
