### PR TITLE
OM-3058: remove trim for array, causing break in exports

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/ApiPlatform/ApiPlatformFieldAnnotations.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/ApiPlatform/ApiPlatformFieldAnnotations.php
@@ -117,7 +117,7 @@ abstract class ApiPlatformFieldAnnotations
                 $this->fields[$name] =  (object)[
                     'filterName' => trim($name),
                     'name' => trim($name),
-                    'modifiers' => trim($rawFilterDetails),
+                    'modifiers' => $rawFilterDetails,
                 ];
             }
         }


### PR DESCRIPTION
hotfix for 1.x fixes bug that was introduced in b9704fb remove trim at line 120 ApiPlatformFieldAnnotations